### PR TITLE
Theme Refactor - separate presentation style from theme

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,30 +3,15 @@ import Content from "./Content";
 import { connect } from "react-redux";
 import { Dispatch } from "../actions";
 import { startApplication } from "../actions/application";
+import { Header } from "./theme/Header";
 
 type OwnProps = ReturnType<typeof mapDispatchToProps>;
-
-function Header() {
-  return (
-    <header>
-      <div
-        style={{
-          margin: "1rem 0",
-          textAlign: "center",
-          borderBottom: "2px solid black"
-        }}
-      >
-        <h1>Beat the Nerd</h1>
-      </div>
-    </header>
-  );
-}
 
 class App extends React.Component<OwnProps> {
   render() {
     return (
-      <div className="App">
-        <Header />
+      <div>
+        <Header title="Beat the Nerd" />
         <Content />
       </div>
     );

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -2,17 +2,10 @@ import React from "react";
 import InputBox from "./InputBox";
 import MessageList from "./MessageList";
 
-const style = {
-  yMargins: {
-    marginTop: "2rem",
-    marginBottom: "4rem"
-  }
-};
-
 export default function Content() {
   return (
     <div>
-      <MessageList style={style.yMargins} />
+      <MessageList />
       <InputBox />
     </div>
   );

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -3,6 +3,10 @@ import { connect } from "react-redux";
 import { Dispatch } from "../actions";
 import { askQuestion } from "../actions/message";
 import { applicationChangeState } from "../actions/application";
+import { NESField } from "./theme/NESField";
+import { NESFormWrapper } from "./theme/NESFormWrapper";
+import { NESInputText } from "./theme/NESInputText";
+import { NESSubmitButton } from "./theme/NESSubmitButton";
 
 type OwnState = {
   message: string;
@@ -11,6 +15,15 @@ type OwnState = {
 type OwnProps = ReturnType<typeof mapDispatchToProps>;
 
 const INITIAL_STATE = { message: "" };
+
+const styles: { [key: string]: React.CSSProperties } = {
+  formWrapper: {
+    position: "fixed",
+    bottom: 0
+  },
+  form: { display: "flex" },
+  inputTextWrapper: { flex: 1 }
+};
 
 class InputBox extends React.Component<OwnProps, OwnState> {
   constructor(props: OwnProps) {
@@ -46,38 +59,29 @@ class InputBox extends React.Component<OwnProps, OwnState> {
     const { message } = this.state;
 
     return (
-      <div
-        style={{
-          position: "fixed",
-          bottom: 0,
-          width: "100%",
-          backgroundColor: "white"
-        }}
-      >
+      <NESFormWrapper style={styles.formWrapper}>
         <form
           onSubmit={(event: React.FormEvent<HTMLFormElement>) =>
             this.handleSubmit(event)
           }
-          style={{ display: "flex" }}
+          style={styles.form}
         >
-          <div className="nes-field" style={{ flex: 1 }}>
-            <input
-              type="text"
+          <NESField style={styles.inputTextWrapper}>
+            <NESInputText
               value={message}
+              placeholder="Type your question here"
+              name="message"
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                 this.handleChange(event)
               }
-              name="message"
-              className="nes-input"
-              placeholder="Type your question here"
               ref={this.focusedInput}
             />
-          </div>
-          <div className="nes-field">
-            <input type="submit" value="Send" className="nes-btn is-primary" />
-          </div>
+          </NESField>
+          <NESField>
+            <NESSubmitButton value="Send" primary={true} />
+          </NESField>
         </form>
-      </div>
+      </NESFormWrapper>
     );
   }
 }

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MessageType } from "../actions/message";
-import classNames from "classnames";
 import UIDs from "./UserIds";
+import { NESMessage } from "./theme/NESMessage";
 
 type OwnProps = {
   data?: MessageType;
@@ -12,22 +12,9 @@ const Message: React.FunctionComponent<OwnProps> = ({ data, children }) => {
   const isCpuMessage = !isUserMessage;
 
   return (
-    <section
-      className={classNames("message", isCpuMessage ? "-left" : "-right")}
-    >
-      {isCpuMessage && <i className="nes-mario"></i>}
-      <div
-        className={classNames(
-          "nes-balloon",
-          { "from-left": isCpuMessage },
-          { "from-right": isUserMessage }
-        )}
-      >
-        {children}
-        {data && <p>{data.text}</p>}
-      </div>
-      {isUserMessage && <i className="nes-bcrikko"></i>}
-    </section>
+    <NESMessage isLeftHanded={isCpuMessage} message={data && data.text}>
+      {children}
+    </NESMessage>
   );
 };
 

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -5,12 +5,15 @@ import LoadingAnimation from "./LoadingAnimation";
 import { giveAnswer } from "../actions/message";
 import { Dispatch } from "../actions";
 import Message from "./Message";
+import { NESMessageList } from "./theme/NESMessageList";
 
-type OwnProps = { style?: React.CSSProperties };
-
-type Props = OwnProps &
-  ReturnType<typeof mapStateToProps> &
+type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
+
+const style: React.CSSProperties = {
+  marginTop: "2rem",
+  marginBottom: "4rem"
+};
 
 class MessageList extends React.Component<Props> {
   constructor(props: Props) {
@@ -38,20 +41,20 @@ class MessageList extends React.Component<Props> {
     const messages = this.props.messages;
 
     return (
-      <section className="nes-container with-title" style={this.props.style}>
-        <p className="title">Messages</p>
-        <section className="message-list">
-          {messages.map((m, i) => (
-            <Message data={m} key={m.id} />
-          ))}
-          {this.props.isCPUAnswering && (
-            <Message>
-              <LoadingAnimation />
-            </Message>
-          )}
-        </section>
-        <div ref={this.messagesEndlineRef}></div>
-      </section>
+      <NESMessageList
+        ref={this.messagesEndlineRef}
+        style={style}
+        title="Messages"
+      >
+        {messages.map((m, i) => (
+          <Message data={m} key={m.id} />
+        ))}
+        {this.props.isCPUAnswering && (
+          <Message>
+            <LoadingAnimation />
+          </Message>
+        )}
+      </NESMessageList>
     );
   }
 }

--- a/src/components/theme/Header.tsx
+++ b/src/components/theme/Header.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+type HeaderProps = {
+  title: string;
+};
+
+export const Header: React.FunctionComponent<HeaderProps> = ({ title }) => (
+  <header>
+    <div
+      style={{
+        margin: "1rem 0",
+        textAlign: "center",
+        borderBottom: "2px solid black"
+      }}
+    >
+      <h1>{title}</h1>
+    </div>
+  </header>
+);

--- a/src/components/theme/NESField.tsx
+++ b/src/components/theme/NESField.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+type NESFieldProps = Pick<React.HTMLAttributes<HTMLDivElement>, "style">;
+
+export const NESField: React.FunctionComponent<NESFieldProps> = ({
+  style,
+  children
+}) => (
+  <div className="nes-field" style={style}>
+    {children}
+  </div>
+);

--- a/src/components/theme/NESFormWrapper.tsx
+++ b/src/components/theme/NESFormWrapper.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+type NESFormWrapperProps = Pick<React.HTMLAttributes<HTMLDivElement>, "style">;
+
+export const NESFormWrapper: React.FunctionComponent<NESFormWrapperProps> = ({
+  style,
+  children
+}) => {
+  const fullStyle: React.CSSProperties = {
+    ...style,
+    backgroundColor: "white",
+    width: "100%"
+  };
+  return <div style={fullStyle}>{children}</div>;
+};

--- a/src/components/theme/NESInputText.tsx
+++ b/src/components/theme/NESInputText.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+type NESInputTextOwnProps = {
+  primary?: boolean;
+};
+
+type NESInputTextProps = Partial<
+  NESInputTextOwnProps &
+    Pick<
+      React.AllHTMLAttributes<HTMLInputElement>,
+      "value" | "placeholder" | "name" | "onChange"
+    >
+>;
+
+export const NESInputText = React.forwardRef(
+  (props: NESInputTextProps, ref: React.Ref<HTMLInputElement>) => (
+    <input
+      type="text"
+      value={props.value}
+      onChange={props.onChange}
+      name={props.name}
+      className="nes-input"
+      placeholder={props.placeholder}
+      ref={ref}
+    />
+  )
+);

--- a/src/components/theme/NESMessage.tsx
+++ b/src/components/theme/NESMessage.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import classNames from "classnames";
+
+type NESMessageProps = {
+  isLeftHanded: boolean;
+  message?: string;
+};
+
+export const NESMessage: React.FunctionComponent<NESMessageProps> = ({
+  isLeftHanded,
+  message,
+  children
+}) => (
+  <section className={classNames("message", isLeftHanded ? "-left" : "-right")}>
+    {isLeftHanded && <i className="nes-mario"></i>}
+    <div
+      className={classNames(
+        "nes-balloon",
+        isLeftHanded ? "from-left" : "from-right"
+      )}
+    >
+      {message ? <p>{message}</p> : children}
+    </div>
+    {!isLeftHanded && <i className="nes-bcrikko"></i>}
+  </section>
+);

--- a/src/components/theme/NESMessageList.tsx
+++ b/src/components/theme/NESMessageList.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import classNames from "classnames";
+
+type NESMessageListOwnProps = Pick<
+  React.HTMLAttributes<HTMLDivElement>,
+  "title" | "style"
+>;
+
+type NESMessageListProps = Partial<
+  React.PropsWithChildren<NESMessageListOwnProps>
+>;
+
+export const NESMessageList = React.forwardRef(
+  (props: NESMessageListProps, ref: React.Ref<HTMLDivElement>) => (
+    <section
+      className={classNames("nes-container", { "with-title": props.title })}
+      style={props.style}
+    >
+      {props.title && <p className="title">{props.title}</p>}
+      <section className="message-list">{props.children}</section>
+      <div ref={ref}></div>
+    </section>
+  )
+);

--- a/src/components/theme/NESSubmitButton.tsx
+++ b/src/components/theme/NESSubmitButton.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import classNames from "classnames";
+
+type NESSubmitButtonOwnProps = {
+  primary?: boolean;
+};
+
+type NESSubmitButtonProps = Partial<
+  NESSubmitButtonOwnProps &
+    Pick<React.AllHTMLAttributes<HTMLButtonElement>, "value">
+>;
+
+export const NESSubmitButton: React.FunctionComponent<NESSubmitButtonProps> = ({
+  value,
+  primary
+}) => (
+  <input
+    type="submit"
+    value={value}
+    className={classNames("nes-btn", { "is-primary": primary })}
+  />
+);


### PR DESCRIPTION
This PR aims to add a components set strictly related to NES theme. This set wraps class names and style strictly related to NES, separating theming from the composition of the page.